### PR TITLE
fix: use path dependency for kiss_repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,16 +1,3 @@
-<!--
-This README describes the package. If you publish this package to pub.dev,
-this README's contents appear on the landing page for your package.
-
-For information about how to write a good package README, see the guide for
-[writing package pages](https://dart.dev/tools/pub/writing-package-pages).
-
-For general information about developing packages, see the Dart guide for
-[creating packages](https://dart.dev/guides/libraries/create-packages)
-and the Flutter guide for
-[developing packages and plugins](https://flutter.dev/to/develop-packages).
--->
-
 # PocketBase Repository
 
 A PocketBase implementation of the `kiss_repository` interface.

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -8,7 +8,8 @@ environment:
 
 dependencies:
   pocketbase: ^0.22.0
-  kiss_repository: ^0.9.0
+  kiss_repository:
+    path: ../kiss_repository
 
 dev_dependencies:
   test: ^1.24.0

--- a/test/integration/pocketbase_query_builder.dart
+++ b/test/integration/pocketbase_query_builder.dart
@@ -4,7 +4,7 @@ import '../../../kiss_repository/shared_test_logic/data/queries.dart';
 
 /// PocketBase-specific query builder for ProductModel
 /// Uses PocketBase filter syntax: https://pocketbase.io/docs/api-rules-and-filters/
-class ProductModelQueryBuilder implements QueryBuilder<String> {
+class TestPocketBaseProductQueryBuilder implements QueryBuilder<String> {
   @override
   String build(Query query) {
     if (query is QueryByName) {

--- a/test/integration/pocketbase_query_builder.dart
+++ b/test/integration/pocketbase_query_builder.dart
@@ -9,7 +9,8 @@ class TestPocketBaseProductQueryBuilder implements QueryBuilder<String> {
   String build(Query query) {
     if (query is QueryByName) {
       // PocketBase uses ~ operator for "contains/like" matching
-      return 'name ~ "${query.namePrefix}"';
+      final escaped = _escapePocketBaseFilterString(query.namePrefix);
+      return 'name ~ "$escaped"';
     }
 
     if (query is QueryByCreatedAfter) {
@@ -28,6 +29,10 @@ class TestPocketBaseProductQueryBuilder implements QueryBuilder<String> {
       return 'price < ${query.price}';
     }
 
-    return '';
+    throw UnsupportedError('ProductModelQueryBuilder: unsupported query type \\${query.runtimeType}');
   }
+}
+
+String _escapePocketBaseFilterString(String input) {
+  return input.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
 }

--- a/test/integration/pocketbase_query_builder.dart
+++ b/test/integration/pocketbase_query_builder.dart
@@ -1,0 +1,33 @@
+import 'package:kiss_repository/kiss_repository.dart';
+
+import '../../../kiss_repository/shared_test_logic/data/queries.dart';
+
+/// PocketBase-specific query builder for ProductModel
+/// Uses PocketBase filter syntax: https://pocketbase.io/docs/api-rules-and-filters/
+class ProductModelQueryBuilder implements QueryBuilder<String> {
+  @override
+  String build(Query query) {
+    if (query is QueryByName) {
+      // PocketBase uses ~ operator for "contains/like" matching
+      return 'name ~ "${query.namePrefix}"';
+    }
+
+    if (query is QueryByCreatedAfter) {
+      return 'created >= "${query.date.toIso8601String()}"';
+    }
+
+    if (query is QueryByCreatedBefore) {
+      return 'created <= "${query.date.toIso8601String()}"';
+    }
+
+    if (query is QueryByPriceGreaterThan) {
+      return 'price > ${query.price}';
+    }
+
+    if (query is QueryByPriceLessThan) {
+      return 'price < ${query.price}';
+    }
+
+    return '';
+  }
+}

--- a/test/integration/test_helpers.dart
+++ b/test/integration/test_helpers.dart
@@ -43,7 +43,7 @@ class IntegrationTestHelpers {
         'description': productModel.description,
         'created': productModel.created.toIso8601String(),
       },
-      queryBuilder: ProductModelQueryBuilder(),
+      queryBuilder: TestPocketBaseProductQueryBuilder(),
     );
   }
 

--- a/test/integration/test_helpers.dart
+++ b/test/integration/test_helpers.dart
@@ -2,7 +2,7 @@ import 'package:pocketbase/pocketbase.dart';
 import 'package:kiss_pocketbase_repository/kiss_pocketbase_repository.dart';
 
 import '../../../kiss_repository/shared_test_logic/data/product_model.dart';
-import '../../../kiss_repository/shared_test_logic/data/queries.dart';
+import 'pocketbase_query_builder.dart';
 
 class IntegrationTestHelpers {
   static late PocketBase pocketbaseClient;


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Documentation**
  - Updated the README to remove introductory guidance and start directly with the package description.

- **Chores**
  - Changed the dependency source for `kiss_repository` to use a local path instead of a published version.

- **New Features**
  - Added a new query builder to support advanced filtering in PocketBase integration tests.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->