### PR TITLE
fix(test): bind PocketBase filter values instead of interpolating (#7)

### DIFF
--- a/test/integration/factories/pocketbase_query_builder.dart
+++ b/test/integration/factories/pocketbase_query_builder.dart
@@ -1,33 +1,57 @@
 import 'package:kiss_repository/kiss_repository.dart';
 import 'package:kiss_repository_tests/kiss_repository_tests.dart';
+import 'package:pocketbase/pocketbase.dart';
 
 /// PocketBase-specific query builder for ProductModel
 /// Uses PocketBase filter syntax: https://pocketbase.io/docs/api-rules-and-filters/
+///
+/// Every value is bound through a [PocketBase.filter] placeholder (`{:name}`).
+/// No value is interpolated into the filter string. `filter` quotes a string
+/// value and escapes a single quote inside it, so the value cannot close its
+/// own literal and append filter syntax. `filter` emits a number unquoted.
+///
+/// Copy this pattern, not string interpolation, when you write a query builder
+/// of your own. The rule holds for a numeric field as well: a numeric field can
+/// become a string field later, and an interpolated string field is injectable.
 class TestPocketBaseProductQueryBuilder implements QueryBuilder<String> {
+  TestPocketBaseProductQueryBuilder(this._client);
+
+  final PocketBase _client;
+
   @override
   String build(Query query) {
     if (query is QueryByName) {
       // PocketBase uses ~ operator for "contains/like" matching
-      final escaped = _escapePocketBaseFilterString(query.namePrefix);
-      return 'name ~ "$escaped"';
+      return _client.filter(
+        'name ~ {:namePrefix}',
+        <String, dynamic>{'namePrefix': query.namePrefix},
+      );
     }
-
 
     if (query is QueryByPriceRange) {
       final conditions = <String>[];
       if (query.minPrice != null) {
-        conditions.add('price >= ${query.minPrice}');
+        conditions.add(
+          _client.filter(
+            'price >= {:minPrice}',
+            <String, dynamic>{'minPrice': query.minPrice},
+          ),
+        );
       }
       if (query.maxPrice != null) {
-        conditions.add('price <= ${query.maxPrice}');
+        conditions.add(
+          _client.filter(
+            'price <= {:maxPrice}',
+            <String, dynamic>{'maxPrice': query.maxPrice},
+          ),
+        );
       }
       return conditions.join(' && ');
     }
 
-    throw UnsupportedError('ProductModelQueryBuilder: unsupported query type \\${query.runtimeType}');
+    throw UnsupportedError(
+      'TestPocketBaseProductQueryBuilder: unsupported query type '
+      '${query.runtimeType}',
+    );
   }
-}
-
-String _escapePocketBaseFilterString(String input) {
-  return input.replaceAll(r'\', r'\\').replaceAll('"', r'\"');
 }

--- a/test/integration/factories/pocketbase_repository_factory.dart
+++ b/test/integration/factories/pocketbase_repository_factory.dart
@@ -23,7 +23,7 @@ class PocketBaseRepositoryFactory implements RepositoryFactory<ProductModel> {
     _repository = RepositoryPocketBase<ProductModel>(
       client: _pocketbaseClient,
       collection: _testCollection,
-      queryBuilder: TestPocketBaseProductQueryBuilder(),
+      queryBuilder: TestPocketBaseProductQueryBuilder(_pocketbaseClient),
       fromPocketBase: (record) => ProductModel(
         id: record.id,
         name: record.data['name'] as String,

--- a/test/unit/pocketbase_query_builder_test.dart
+++ b/test/unit/pocketbase_query_builder_test.dart
@@ -1,0 +1,113 @@
+import 'package:kiss_repository/kiss_repository.dart';
+import 'package:kiss_repository_tests/kiss_repository_tests.dart';
+import 'package:pocketbase/pocketbase.dart';
+import 'package:test/test.dart';
+
+import '../integration/factories/pocketbase_query_builder.dart';
+
+void main() {
+  // `filter` only formats a string. It sends no request, so no server is
+  // needed and this URL is never contacted. These tests are therefore unit
+  // tests and they do not need `scripts/start_emulator.sh`.
+  final client = PocketBase('http://localhost:8090');
+  final builder = TestPocketBaseProductQueryBuilder(client);
+
+  group('TestPocketBaseProductQueryBuilder QueryByName', () {
+    test('quotes a plain name prefix', () {
+      expect(builder.build(const QueryByName('laptop')), "name ~ 'laptop'");
+    });
+
+    test('escapes a single quote inside a legitimate value', () {
+      // A real product name, not an attack. It must stay inside one literal.
+      expect(builder.build(const QueryByName("O'Brien")), r"name ~ 'O\'Brien'");
+    });
+
+    test('a crafted name prefix cannot add a filter clause (#7)', () {
+      // Interpolation would end the literal after `x` and append a second
+      // condition. Binding escapes every quote in the value instead, so the
+      // whole value stays one literal and adds no syntax of its own.
+      const crafted = "x' || id != ''";
+
+      expect(
+        builder.build(const QueryByName(crafted)),
+        r"name ~ 'x\' || id != \'\''",
+      );
+    });
+
+    test('a double quote inside a value needs no escaping', () {
+      // The emitted literal is single quoted, so a double quote is ordinary
+      // text. The deleted helper escaped this character; `filter` does not.
+      expect(
+        builder.build(const QueryByName('say "hi"')),
+        "name ~ 'say \"hi\"'",
+      );
+    });
+  });
+
+  group('TestPocketBaseProductQueryBuilder QueryByPriceRange', () {
+    test('emits a bare number for a minimum price', () {
+      expect(
+        builder.build(const QueryByPriceRange(minPrice: 10.5)),
+        'price >= 10.5',
+      );
+    });
+
+    test('emits a bare number for a maximum price', () {
+      expect(
+        builder.build(const QueryByPriceRange(maxPrice: 99.99)),
+        'price <= 99.99',
+      );
+    });
+
+    test('joins both bounds with &&', () {
+      expect(
+        builder.build(const QueryByPriceRange(minPrice: 1, maxPrice: 2)),
+        'price >= 1.0 && price <= 2.0',
+      );
+    });
+
+    test('a bound price carries no quote character', () {
+      // The bound value is a number, so `filter` must not quote it. A quoted
+      // number would compare as text and change the result of the query.
+      final built = builder.build(
+        const QueryByPriceRange(minPrice: 1, maxPrice: 2),
+      );
+
+      expect(built.contains("'"), isFalse);
+      expect(built.contains('"'), isFalse);
+    });
+
+    test('emits an empty filter when neither bound is set', () {
+      expect(builder.build(const QueryByPriceRange()), '');
+    });
+  });
+
+  group('TestPocketBaseProductQueryBuilder unsupported query', () {
+    test('names the query type with no stray backslash', () {
+      // The message used to interpolate through an escaped backslash, so it
+      // read `... unsupported query type \AllQuery`.
+      expect(
+        () => builder.build(const AllQuery()),
+        throwsA(
+          isA<UnsupportedError>().having(
+            (error) => error.message,
+            'message',
+            'TestPocketBaseProductQueryBuilder: unsupported query type '
+                'AllQuery',
+          ),
+        ),
+      );
+    });
+  });
+
+  group('TestPocketBaseProductQueryBuilder known limit', () {
+    test('a value that ends in a backslash escapes its own closing quote', () {
+      // `PocketBase.filter` escapes a single quote and leaves a backslash
+      // alone, so a trailing backslash lands directly before the closing
+      // quote. This is upstream behaviour of `filter`, not of this builder,
+      // and the deleted helper did not handle it either. The test records it
+      // so a later reader does not assume the value is safe in every shape.
+      expect(builder.build(const QueryByName(r'a\')), r"name ~ 'a\'");
+    });
+  });
+}


### PR DESCRIPTION
Closes #7.

## The defect

`test/integration/factories/pocketbase_query_builder.dart` built the price-range filter by interpolating the value into the filter string:

```dart
conditions.add('price >= ${query.minPrice}');
conditions.add('price <= ${query.maxPrice}');
```

`QueryByPriceRange.minPrice` and `maxPrice` are `double?`, so no attacker-controlled text can reach those two lines today. The issue is the code shape, not a live exploit. The same shape on a string field **is** injectable, and that is exactly what it became in the related repository: WAMF/kiss_repository#25, fixed in https://github.com/WAMF/kiss_repository/pull/28.

The file also carried a second pattern for the string field: a hand-rolled `_escapePocketBaseFilterString` helper with double-quoted literals. Two patterns in one 30-line file means a reader must decide which one to copy.

## The fix

Every value now goes through a `PocketBase.filter` placeholder (`{:name}`). `filter` is the upstream parameterization helper, which the issue recommends.

- A string value is wrapped in single quotes and every `'` inside it is escaped. The value cannot close its own literal and append filter syntax.
- A number is emitted unquoted, so `price >= 10.5` still compares as a number.

`_escapePocketBaseFilterString` is deleted. The builder now takes the `PocketBase` client through its constructor; `PocketBaseRepositoryFactory` passes the client it already holds.

One extra line: the `UnsupportedError` message interpolated through an escaped backslash (`'... query type \\${query.runtimeType}'`), so it read `... unsupported query type \QueryByPriceRange`. That is on the line the change rewrites, so it is fixed here and pinned by a test.

## Verification

`dart analyze`: **72 issues before, 72 after**, all `info`, all pre-existing `lines_longer_than_80_chars` in other files. Zero errors and zero warnings. My two files add no new issue.

New file `test/unit/pocketbase_query_builder_test.dart`: **11 tests, all passing.** `filter` only formats a string and sends no request, so these are unit tests. They need no PocketBase server and they do not use `scripts/start_emulator.sh`.

```
$ dart test test/unit/
00:00 +11: All tests passed!
```

### Mutation results

I mutated the production code 7 times to prove the tests are load-bearing. Each mutation was asserted to have applied before the tests ran, and the source checksum is identical before and after the run.

| # | Mutation | Result |
|---|---|---|
| M1 | The name prefix is interpolated again (the original defect shape) | KILLED |
| M2 | `minPrice` is interpolated again (the shape this issue reports) | **SURVIVED** |
| M3 | The bound `maxPrice` number is quoted | KILLED |
| M4 | The stray backslash in the error message is restored | KILLED |
| M5 | `>=` becomes `>` | KILLED |
| M6 | The two bounds are joined with `\|\|` instead of `&&` | KILLED |
| M7 | The name placeholder is bound to a literal instead of the value | KILLED |

**M2 survived, and that is correct.** It is an equivalent mutant. `minPrice` is `double?`, and `filter` emits a number with `value.toString()` — the same text Dart interpolation produces, for every `double` including `Infinity` and `NaN`. No test can separate the two while the field stays numeric. I am reporting this instead of adding a contrived test to hide it.

So the numeric half of this change is a pattern fix, not a behaviour fix. The behaviour that the tests do pin is the string half (M1, M7), the number-stays-unquoted invariant (M3), the operators (M5, M6), and the message (M4).

## Known limit, recorded not hidden

`PocketBase.filter` escapes a single quote and leaves a backslash alone. A value that ends in a backslash therefore lands directly before the closing quote and escapes it:

```
'a\' + trailing backslash  ->  name ~ 'a\'
```

This is upstream behaviour of `filter`, not of this builder. The deleted helper did not handle it either — it doubled the backslash, which `fexpr` also reads as an escape. The last test in the new file records this so a later reader does not assume every value shape is safe.

## What I did not run

The integration suite under `test/integration/` needs a live PocketBase server (`scripts/start_emulator.sh`). I have no server in this workspace, so I did not run it. The change to `pocketbase_repository_factory.dart` is one argument, and `dart analyze` proves it compiles. A reviewer with an emulator can confirm the emitted single-quoted literals behave the same as the previous double-quoted ones; both are valid PocketBase string literals.

---

Found and fixed during a proactive repository sweep (Riker, 2026-08-09). I claimed the issue before starting: https://github.com/WAMF/kiss_pocketbase_repository/issues/7#issuecomment-5229312952
